### PR TITLE
Make moderator and host view responsive

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,29 +1,34 @@
+@import url('https://fonts.googleapis.com/css?family=Work+Sans:400,600');
+
 body {
-    font: 13px Helvetica, Arial;
-    padding-left: 15px;
-    padding-top: 10px;
+    font: 13px "Work Sans", Helvetica, Arial;
+    overflow-x: hidden;
     overflow-y: hidden;
 }
 
 .container {
     width: 100%;
+    height: 100%;
+    position: absolute;
 }
 
 #messages {
-    width: 750px;
+    width: 48%;
     float: left;
-    height: 800px;
+    height: 96%;
     overflow-y: scroll;
 }
 
 #questions {
-    margin-left: 770px;
-    height: 800px;
+    width: 48%;
+    height: 96%;
     overflow-y: scroll;
 }
 
 #avatar {
     float: left;
+    width: 32px;
+    height: 32px;
     border-radius: 50%;
     margin-right: 15px;
 }


### PR DESCRIPTION
Adding width and height percentages to make moderator and host view scale. Also, reduce avatar size to be the same size as in YouTube Live Chat (32px).